### PR TITLE
Fixing link to CONTRIBUTING.md within README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # hello-worlds
 Collection of Hello World programs.
-### Before you contribute, please see [CONTRIBUTION GUIDE](https://github.com/knightking100/hello-worlds/blob/master/CONTRIBUTING.MD)
+### Before you contribute, please see [CONTRIBUTION GUIDE](https://github.com/knightking100/hello-worlds/blob/master/CONTRIBUTING.md#how-to-contribute)


### PR DESCRIPTION
Currently links to 404 page

File name was changed in commit [6e811259da9468a0dd78df48605ea516d0484bf2](https://github.com/knightking100/hello-worlds/commit/6e811259da9468a0dd78df48605ea516d0484bf2) causing the 404.